### PR TITLE
Fix issue with resultModels on child model

### DIFF
--- a/index.js
+++ b/index.js
@@ -665,13 +665,13 @@ order by c.column_id`, (err, result) => {
     .then(() => {
       for (let factory of results.keys()) {
         for (let field of Object.keys(factory.map)) {
-          let lfield = this.map[field].local;
-          let rfield = this.map[field].remote;
-          let relFactory = this.getModel(this.map[field].collection || this.map[field].model);
+          let lfield = factory.map[field].local;
+          let rfield = factory.map[field].remote;
+          let relFactory = this.getModel(factory.map[field].collection || factory.map[field].model);
           (results.get(factory)).forEach( (local) => {
             (results.get(relFactory)).forEach( (remote) => {
               if (remote[rfield] == local[lfield]) {
-                if (this.map[field].collection) {
+                if (factory.map[field].collection) {
                   if (!local[field]) {
                     local[field] = [];
                   }


### PR DESCRIPTION
Ran into an issue were a child model, that contained a property with the same name as parent, was getting the results loaded from parent record set. This changed appears to fix my issue. Probably not explaining very well but hoping the small change explains itself...
